### PR TITLE
Påvirke $wrapper_classes basert på innhold fra modulen

### DIFF
--- a/includes/class-module.php
+++ b/includes/class-module.php
@@ -65,15 +65,6 @@ abstract class Module {
 
 		$this->name = strtolower( substr( strrchr( get_class( $this ), '\\' ), 1 ) );
 		$this->field_key = 'hogan_module_' . $this->name;
-
-		$this->wrapper_classes = array_merge(
-			apply_filters( 'hogan/module/wrapper_classes', [
-				'hogan-module',
-			] ),
-			apply_filters( 'hogan/module/' . $this->name . '/wrapper_classes', [
-				'hogan-module-' . $this->name,
-			] )
-		);
 	}
 
 	/**
@@ -118,6 +109,16 @@ abstract class Module {
 	 * Render module template.
 	 */
 	public function render_template() {
+
+		$this->wrapper_classes = array_merge(
+			apply_filters( 'hogan/module/wrapper_classes', [
+				'hogan-module',
+			] ),
+			apply_filters( 'hogan/module/' . $this->name . '/wrapper_classes', [
+				'hogan-module-' . $this->name,
+			], $this )
+		);
+
 		include apply_filters( 'hogan/module/' . $this->name . '/template', $this->template );
 	}
 

--- a/includes/class-module.php
+++ b/includes/class-module.php
@@ -102,14 +102,11 @@ abstract class Module {
 	 * @param array $content Content values.
 	 */
 	public function load_args_from_layout_content( $content ) {
+
+		// Global content is loaded after module content.
 		$this->raw_content = $content;
-	}
 
-	/**
-	 * Render module template.
-	 */
-	public function render_template() {
-
+		// Set wrapper classes after all content is set, directly before render.
 		$this->wrapper_classes = array_merge(
 			apply_filters( 'hogan/module/wrapper_classes', [
 				'hogan-module',
@@ -118,7 +115,12 @@ abstract class Module {
 				'hogan-module-' . $this->name,
 			], $this )
 		);
+	}
 
+	/**
+	 * Render module template.
+	 */
+	public function render_template() {
 		include apply_filters( 'hogan/module/' . $this->name . '/template', $this->template );
 	}
 


### PR DESCRIPTION
`$wrapper_classes` blir i dag satt i konstruktøren til en modul. Dette er før modulen får tildelt innhold så vi har ingen mulighet til å legge til eller endre `$wrapper_classes` basert på innholdet. I tillegg sendes ikke modul-objektet med i filteret.

Jeg forslår at vi flytter koden som setter `$wrapper_classes` til `load_args_from_layout_content()` og sender med instansen av modulen som valgfritt argument i filteret.

Proof of Concept:

```php
// Her legger jeg til et ekstra tekstfelt foran WYSIWYG-feltet i tekstmodulen.
add_filter( 'hogan/module/text/fields/pre', function( $fields ) {

    $fields[] = [
        'type' => 'text',
        'key' => 'extra_classes_key',
        'name' => 'extra_classes',
        'label' => 'Ekstra CSS-klasser til tekstmodulwrapper',
    ];

    return $fields;
}, 10, 1 );

/* Her legger jeg til ekstra klasser til wrapper basert på innhold
 * fra ekstrafeltet definert over. På dette tidspunktet har $module
 * satt alt av innhold, både standardfelter og ekstrafelter tilgjengelig via raw_content.
 */
add_filter( 'hogan/module/text/wrapper_classes', function( $classes, $module ) {
    $classes[] = $module->raw_content['extra_classes'];
    return $classes;
}, 10, 2 );
```