### PR TITLE
Rendring av modulwrapper (HTML section-element) i core

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,2 @@
 .DS_Store
-/vendor
-/wp-content/plugins
+vendor

--- a/includes/class-core.php
+++ b/includes/class-core.php
@@ -296,8 +296,7 @@ class Core {
 						if ( $module instanceof Module ) {
 							ob_start();
 
-							$module->load_args_from_layout_content( $layout );
-							$module->render_template();
+							$module->render_template( $layout );
 
 							$flexible_content .= ob_get_clean();
 						}

--- a/includes/class-module.php
+++ b/includes/class-module.php
@@ -141,8 +141,12 @@ abstract class Module {
 		// Output HTML wrapper start.
 		echo sprintf( '<%s class="%s">', esc_attr( $wrapper_tag ), esc_attr( $this->get_wrapper_classes( true ) ) );
 
+		do_action( 'hogan/module/' . $this->name . '/template/before_include', $this );
+
 		// Include module template.
 		include apply_filters( 'hogan/module/' . $this->name . '/template', $this->template );
+
+		do_action( 'hogan/module/' . $this->name . '/template/after_include', $this );
 
 		// Output HTML wrapper end.
 		echo sprintf( '</%s>', esc_attr( $wrapper_tag ) );

--- a/includes/class-module.php
+++ b/includes/class-module.php
@@ -119,9 +119,37 @@ abstract class Module {
 
 	/**
 	 * Render module template.
+	 *
+	 * @param string  $raw_content Raw ACF layout content.
+	 * @param boolean $echo Echo content.
 	 */
-	public function render_template() {
+	public function render_template( $raw_content, $echo = true ) {
+
+		// Load module data from raw ACF layout content.
+		$this->load_args_from_layout_content( $raw_content );
+
+		if ( false === $echo ) {
+			ob_start();
+		}
+
+		// Global HTML wrapper tag.
+		$wrapper_tag = apply_filters( 'hogan/module/wrapper_tag', 'section' );
+
+		// Override wrapper tag for module.
+		$wrapper_tag = apply_filters( 'hogan/module/' . $this->name . '/wrapper_tag', $wrapper_tag );
+
+		// Output HTML wrapper start.
+		echo sprintf( '<%s class="%s">', esc_attr( $wrapper_tag ), esc_attr( $this->get_wrapper_classes( true ) ) );
+
+		// Include module template.
 		include apply_filters( 'hogan/module/' . $this->name . '/template', $this->template );
+
+		// Output HTML wrapper end.
+		echo sprintf( '</%s>', esc_attr( $wrapper_tag ) );
+
+		if ( false === $echo ) {
+			return ob_get_clean();
+		}
 	}
 
 	/**


### PR DESCRIPTION
Her er mitt forslag på hvordan vi kan rendre `<section>` elementet globalt i core istedenfor i template to hver modul. Dette er basically den samme koden som du pastet på Slack i dag Peder. Jeg har lagt inn et parameter `$echo = true` slik at man kan få ut rendret HTML for hver modul som en string eller echo direkte ut. Da vi allerede bruker `ob_start()` i `get_modules_content()` er det ikke hensiktsmessig å gjøre dette for hver modul i tillegg, derfor et valg.

Diskuteres på workshop i morgen.