### PR TITLE
1.0.3

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -5,7 +5,7 @@
   "type": "wordpress-plugin",
   "license": "GPL-3.0",
   "require": {
-    "php": ">=5.5",
+    "php": ">=7.0",
     "composer/installers": "~1.2"
   }
 }

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#composer-lock-the-lock-file",
         "This file is @generated automatically"
     ],
-    "content-hash": "844f5400df862e7375e75175bbe4381c",
+    "content-hash": "94c6e678ba79a9adfb904b9358141360",
     "packages": [
         {
             "name": "composer/installers",
@@ -131,7 +131,7 @@
     "prefer-stable": false,
     "prefer-lowest": false,
     "platform": {
-        "php": ">=5.5"
+        "php": ">=7.0"
     },
     "platform-dev": []
 }

--- a/hogan-core.php
+++ b/hogan-core.php
@@ -4,7 +4,7 @@
  * Plugin URI: https://github.com/DekodeInteraktiv/hogan-core
  * GitHub Plugin URI: https://github.com/DekodeInteraktiv/hogan-core
  * Description: Modular Flexible Content System for ACF Pro
- * Version: 1.0.2
+ * Version: 1.0.3
  * Author: Dekode
  * Author URI: https://dekode.no
  * License: GPL-3.0

--- a/hogan-core.php
+++ b/hogan-core.php
@@ -25,12 +25,7 @@ require_once 'includes/class-module.php';
 require_once 'includes/class-core.php';
 require_once 'includes/helper-functions.php';
 
-global $hogan;
+$_dir = dirname( plugin_basename( __FILE__ ) );
+$_url = plugin_dir_url( __FILE__ );
 
-if ( ! isset( $hogan ) ) {
-
-	$_dir = dirname( plugin_basename( __FILE__ ) );
-	$_url = plugin_dir_url( __FILE__ );
-
-	$hogan = new Dekode\Hogan\Core( $_dir, $_url );
-}
+\Dekode\Hogan\Core::get_instance( $_dir, $_url );

--- a/hogan-core.php
+++ b/hogan-core.php
@@ -17,6 +17,8 @@
  * @author Dekode
  */
 
+declare( strict_types = 1 );
+
 if ( ! defined( 'ABSPATH' ) ) {
 	exit; // Exit if accessed directly.
 }

--- a/hogan-core.php
+++ b/hogan-core.php
@@ -2,6 +2,7 @@
 /**
  * Plugin Name: Hogan
  * Plugin URI: https://github.com/DekodeInteraktiv/hogan-core
+ * GitHub Plugin URI: https://github.com/DekodeInteraktiv/hogan-core
  * Description: Modular Flexible Content System for ACF Pro
  * Version: 1.0.2
  * Author: Dekode

--- a/includes/class-core.php
+++ b/includes/class-core.php
@@ -32,23 +32,23 @@ class Core {
 	/**
 	 * Field groups.
 	 *
-	 * @var array $field_groups
+	 * @var array $_field_groups
 	 */
-	private $field_groups = [];
+	private $_field_groups = [];
 
 	/**
 	 * Modules.
 	 *
-	 * @var array $modules
+	 * @var array $_modules
 	 */
-	private $modules = [];
+	private $_modules = [];
 
 	/**
 	 * Hold the class instance.
 	 *
-	 * @var Core $instance
+	 * @var Core $_instance
 	 */
-	private static $instance = null;
+	private static $_instance = null;
 
 	/**
 	 * Priority for the_content filter.
@@ -110,11 +110,11 @@ class Core {
 	 */
 	public static function get_instance( string $dir = '', string $url = '' ) : Core {
 
-		if ( null === self::$instance ) {
-			self::$instance = new Core( $dir, $url );
+		if ( null === self::$_instance ) {
+			self::$_instance = new Core( $dir, $url );
 		}
 
-		return self::$instance;
+		return self::$_instance;
 	}
 
 	/**
@@ -151,7 +151,7 @@ class Core {
 				$module = new $module();
 			}
 
-			$this->modules[ $module->name ] = $module;
+			$this->_modules[ $module->name ] = $module;
 		}
 
 		do_action( 'hogan/modules_registered' );
@@ -191,7 +191,7 @@ class Core {
 		// Sanitized field group name will be used for all filters, and prefix for field group and field names.
 		$name = sanitize_key( $name );
 
-		$this->field_groups[] = $name;
+		$this->_field_groups[] = $name;
 
 		if ( true !== apply_filters( 'hogan/field_group/' . $name . '/enabled', true ) ) {
 			return;
@@ -211,7 +211,7 @@ class Core {
 				return $module->get_layout_definition();
 			}
 
-		}, $this->modules ) );
+		}, $this->_modules ) );
 
 		if ( empty( $field_group_layouts ) ) {
 			// No modules, no fun.
@@ -323,7 +323,7 @@ class Core {
 
 		if ( empty( $flexible_content ) ) {
 
-			foreach ( $this->field_groups as $field_group ) {
+			foreach ( $this->_field_groups as $field_group ) {
 
 				$layouts = get_field( 'hogan_' . $field_group . '_modules_name', $post );
 
@@ -338,7 +338,7 @@ class Core {
 						}
 
 						// Get the right module.
-						$module = true === isset( $this->modules[ $layout['acf_fc_layout'] ] ) ? $this->modules[ $layout['acf_fc_layout'] ] : null;
+						$module = true === isset( $this->_modules[ $layout['acf_fc_layout'] ] ) ? $this->_modules[ $layout['acf_fc_layout'] ] : null;
 
 						if ( $module instanceof Module ) {
 							ob_start();

--- a/includes/class-core.php
+++ b/includes/class-core.php
@@ -43,12 +43,19 @@ class Core {
 	private $modules = [];
 
 	/**
+	 * Hold the class instance.
+	 *
+	 * @var Core $instance
+	 */
+	private static $instance = null;
+
+	/**
 	 * Module constructor.
 	 *
 	 * @param string $dir Plugin base directory.
 	 * @param string $url Plugin base url.
 	 */
-	public function __construct( $dir, $url ) {
+	private function __construct( $dir, $url ) {
 		$this->dir = $dir;
 		$this->url = $url;
 
@@ -81,6 +88,22 @@ class Core {
 		if ( true === apply_filters( 'hogan/flexible_content_layouts_collapsed_by_default', false ) && is_admin() ) {
 			add_action( 'acf/input/admin_footer', [ $this, 'append_footer_script_for_collapsed_flexible_content_layouts' ] );
 		};
+	}
+
+	/**
+	 * Get Core instance.
+	 *
+	 * @param string $dir Plugin base directory.
+	 * @param string $url Plugin base url.
+	 * @return Core Core instance.
+	 */
+	public static function get_instance( string $dir = '', string $url = '' ) : Core {
+
+		if ( null === self::$instance ) {
+			self::$instance = new Core( $dir, $url );
+		}
+
+		return self::$instance;
 	}
 
 	/**

--- a/includes/class-core.php
+++ b/includes/class-core.php
@@ -5,6 +5,7 @@
  * @package Hogan
  */
 
+declare( strict_types = 1 );
 namespace Dekode\Hogan;
 
 defined( 'ABSPATH' ) || exit; // Exit if accessed directly.
@@ -54,13 +55,14 @@ class Core {
 	 *
 	 * @var int $the_content_priority
 	 */
-	private $_the_content_priority = 0; //apply_filters( 'hogan/the_content_priority', 10 );
+	private $_the_content_priority = 0;
 
 	/**
 	 * Module constructor.
 	 *
 	 * @param string $dir Plugin base directory.
 	 * @param string $url Plugin base url.
+	 * @return void
 	 */
 	private function __construct( $dir, $url ) {
 		$this->dir = $dir;
@@ -117,6 +119,8 @@ class Core {
 
 	/**
 	 * Load textdomain for translations.
+	 *
+	 * @return void
 	 */
 	public function load_textdomain() {
 		load_plugin_textdomain( 'hogan-core', false, $this->dir . '/languages' );
@@ -124,6 +128,8 @@ class Core {
 
 	/**
 	 * Load plugin admin assets.
+	 *
+	 * @return void
 	 */
 	public function enqueue_admin_assets() {
 		$assets_version = defined( 'SCRIPT_DEBUG' ) && true === SCRIPT_DEBUG ? time() : false;
@@ -132,6 +138,8 @@ class Core {
 
 	/**
 	 * Register modules from filter into core plugin.
+	 *
+	 * @return void
 	 */
 	public function register_modules() {
 
@@ -151,6 +159,8 @@ class Core {
 
 	/**
 	 * Register field groups from filter into core plugin.
+	 *
+	 * @return void
 	 */
 	public function register_field_groups() {
 
@@ -188,7 +198,7 @@ class Core {
 		}
 
 		// Get flexible content layouts from modules.
-		$field_group_layouts = array_filter( array_map( function( $module ) use ( $modules ) {
+		$field_group_layouts = array_filter( array_map( function( Module $module ) use ( $modules ) : array {
 
 			if ( is_array( $modules ) && ! empty( $modules ) ) {
 
@@ -271,15 +281,16 @@ class Core {
 			'send-trackbacks',
 		];
 
-		hogan_register_field_group( 'default', __( 'Content Modules', 'hogan-core' ), null, $location, $hide_on_screen );
+		hogan_register_field_group( 'default', __( 'Content Modules', 'hogan-core' ), [], $location, $hide_on_screen );
 	}
 
 	/**
 	 * Append modules HTML content to the_content for the global post object.
 	 *
 	 * @param string $content Content HTML string.
+	 * @return string
 	 */
-	public function append_modules_content( $content ) {
+	public function append_modules_content( string $content ) : string {
 
 		global $more, $post;
 		$flexible_content = '';
@@ -303,7 +314,7 @@ class Core {
 	 * @param \WP_Post $post The post.
 	 * @return string
 	 */
-	private function get_modules_content( \WP_Post $post ) {
+	private function get_modules_content( \WP_Post $post ) : string {
 
 		$cache_key = 'hogan_modules_' . $post->ID;
 		$cache_group = 'hogan_modules';
@@ -353,7 +364,7 @@ class Core {
 	 * @param \WP_Post $post The post.
 	 * @return \WP_Post
 	 */
-	public function populate_post_content_for_indexing( \WP_Post $post ) {
+	public function populate_post_content_for_indexing( \WP_Post $post ) : \WP_Post {
 
 		// Fake fill the post_content with modules before SearchWP indexing.
 		$post->post_content = $this->get_modules_content( $post );
@@ -366,7 +377,8 @@ class Core {
 	 * @param array $toolbars Current Toolbars.
 	 * @return array $toolbars Array with new toolbars.
 	 */
-	public function append_hogan_wysiwyg_toolbar( $toolbars ) {
+	public function append_hogan_wysiwyg_toolbar( array $toolbars ) : array {
+
 		// TODO: Include blockquote tinymce plugin. 'blockquote_cite'.
 		$toolbars['hogan'] = [
 			1 => [
@@ -403,7 +415,7 @@ class Core {
 	 * @param array $settings TinyMCE settings.
 	 * @return array $settings Optimized TinyMCE settings.
 	 */
-	public function override_tinymce_settings( $settings ) {
+	public function override_tinymce_settings( array $settings ) : array {
 		$settings['block_formats'] = apply_filters( 'hogan/tinymce_block_formats', 'Paragraph=p;Overskrift 2=h2;Overskrift 3=h3;Overskrift4=h4' );
 		return $settings;
 	}

--- a/includes/class-module.php
+++ b/includes/class-module.php
@@ -24,6 +24,13 @@ abstract class Module {
 	public $name;
 
 	/**
+	 * Module heading. Require use of hogan_append_heading_field() in module get_fields() implementation.
+	 *
+	 * @var string $heading
+	 */
+	public $heading;
+
+	/**
 	 * Module field key prefix.
 	 *
 	 * @var string $field_key
@@ -116,7 +123,9 @@ abstract class Module {
 	 */
 	public function load_args_from_layout_content( array $raw_content, int $counter = 0 ) {
 
-		// Global content is loaded after module content.
+		// Load global module content.
+		$this->heading = $raw_content['heading'] ?? '';
+
 		$this->raw_content = $raw_content;
 		$this->counter = $counter;
 	}

--- a/includes/class-module.php
+++ b/includes/class-module.php
@@ -52,6 +52,13 @@ abstract class Module {
 	public $raw_content;
 
 	/**
+	 * Module location in page layout.
+	 *
+	 * @var int $counter Incremental counter.
+	 */
+	public $counter;
+
+	/**
 	 * Template outer wrapper HTML tag.
 	 *
 	 * @var string
@@ -102,14 +109,16 @@ abstract class Module {
 	abstract protected function get_fields();
 
 	/**
-	 * Map raw field values to content array.
+	 * Map raw fields from acf to object variable.
 	 *
-	 * @param array $content Content values.
+	 * @param array $raw_content Content values.
+	 * @param int   $counter Module location in page layout.
 	 */
-	public function load_args_from_layout_content( $content ) {
+	public function load_args_from_layout_content( array $raw_content, int $counter = 0 ) {
 
 		// Global content is loaded after module content.
-		$this->raw_content = $content;
+		$this->raw_content = $raw_content;
+		$this->counter = $counter;
 	}
 
 	/**
@@ -183,7 +192,7 @@ abstract class Module {
 	public function render_template( $raw_content, $counter = 0, $echo = true ) {
 
 		// Load module data from raw ACF layout content.
-		$this->load_args_from_layout_content( $raw_content );
+		$this->load_args_from_layout_content( $raw_content, $counter );
 
 		if ( true !== $this->validate_args() ) {
 			return;

--- a/includes/class-module.php
+++ b/includes/class-module.php
@@ -5,6 +5,7 @@
  * @package Hogan
  */
 
+declare( strict_types = 1 );
 namespace Dekode\Hogan;
 
 if ( ! defined( 'ABSPATH' ) ) {
@@ -90,8 +91,10 @@ abstract class Module {
 
 	/**
 	 * Base class for field definitions.
+	 *
+	 * @return array
 	 */
-	final public function get_layout_definition() {
+	final public function get_layout_definition() : array {
 
 		$sub_fields = array_merge(
 			apply_filters( 'hogan/module/' . $this->name . '/fields_before', [] ),
@@ -111,15 +114,18 @@ abstract class Module {
 	}
 
 	/**
-	 * Field definitions per module.
+	 * Field definitions for module.
+	 *
+	 * @return array $fields Fields for this module
 	 */
-	abstract protected function get_fields();
+	abstract protected function get_fields() : array;
 
 	/**
 	 * Map raw fields from acf to object variable.
 	 *
 	 * @param array $raw_content Content values.
 	 * @param int   $counter Module location in page layout.
+	 * @return void
 	 */
 	public function load_args_from_layout_content( array $raw_content, int $counter = 0 ) {
 
@@ -132,13 +138,16 @@ abstract class Module {
 
 	/**
 	 * Validate module content before template is loaded.
+	 *
+	 * @return bool Whether validation of the module is successful / filled with content.
 	 */
-	abstract protected function validate_args();
+	abstract protected function validate_args() : bool;
 
 	/**
 	 * Render module wrappers opening tags before template include.
 	 *
 	 * @param integer $counter Module number.
+	 * @return void
 	 */
 	protected function render_opening_template_wrappers( $counter = 0 ) {
 
@@ -177,6 +186,8 @@ abstract class Module {
 
 	/**
 	 * Render module wrapper closing tags after template include.
+	 *
+	 * @return void
 	 */
 	protected function render_closing_template_wrappers() {
 
@@ -197,14 +208,15 @@ abstract class Module {
 	 * @param string  $raw_content Raw ACF layout content.
 	 * @param integer $counter Module number.
 	 * @param boolean $echo Echo content.
+	 * @return string
 	 */
-	public function render_template( $raw_content, $counter = 0, $echo = true ) {
+	final public function render_template( $raw_content, $counter = 0, $echo = true ) : string {
 
 		// Load module data from raw ACF layout content.
 		$this->load_args_from_layout_content( $raw_content, $counter );
 
 		if ( true !== $this->validate_args() ) {
-			return;
+			return '';
 		}
 
 		if ( false === $echo ) {
@@ -223,5 +235,7 @@ abstract class Module {
 		if ( false === $echo ) {
 			return ob_get_clean();
 		}
+
+		return '';
 	}
 }

--- a/includes/helper-functions.php
+++ b/includes/helper-functions.php
@@ -5,6 +5,8 @@
  * @package Hogan
  */
 
+declare( strict_types = 1 );
+
 if ( ! defined( 'ABSPATH' ) ) {
 	exit; // Exit if accessed directly.
 }
@@ -12,25 +14,26 @@ if ( ! defined( 'ABSPATH' ) ) {
 /**
  * Registert module
  *
- * @param object $module Module object.
+ * @param \Dekode\Hogan\Module $module Module object.
  *
  * @return void
  */
-function hogan_register_module( $module ) {
+function hogan_register_module( \Dekode\Hogan\Module $module ) {
 
 	if ( did_action( 'hogan/modules_registered' ) ) {
 		_doing_it_wrong( __METHOD__, esc_html__( 'Hogan modules have already been registered. Please run hogan_register_module() on action hogan/include_modules.', 'hogan-core' ), '1.0.0' );
 	}
 
-	add_filter( 'hogan/modules', function( $modules ) use ( $module ) {
+	add_filter( 'hogan/modules', function( array $modules ) use ( $module ) : array {
 		$modules[] = $module;
 		return $modules;
 	} );
-
 }
 
 /**
  * De-register default field group.
+ *
+ * @return void
  */
 function hogan_deregister_default_field_group() {
 
@@ -45,16 +48,15 @@ function hogan_deregister_default_field_group() {
  * Register a specific field group.
  *
  * @param string $name                           Field group name.
- * @param mixed  $label                          Label.
- * @param mixed  $modules                        Array/String with supported modules.
+ * @param string $label                          Label.
+ * @param array  $modules                        Array/String with supported modules.
  * @param array  $location                       Location rules.
  * @param array  $hide_on_screen                 Array of elements to hide on edit screen.
  * @param array  $fields_before_flexible_content Prepend fields.
  * @param array  $fields_after_flexible_content  Append fields.
- *
  * @return void
  */
-function hogan_register_field_group( $name, $label, $modules = [], $location = [], $hide_on_screen = [], $fields_before_flexible_content = [], $fields_after_flexible_content = [] ) {
+function hogan_register_field_group( string $name, string $label, array $modules = [], array $location = [], array $hide_on_screen = [], array $fields_before_flexible_content = [], array $fields_after_flexible_content = [] ) {
 
 	if ( did_action( 'hogan/field_groups_registered' ) ) {
 		_doing_it_wrong( __METHOD__, esc_html__( 'Hogan field groups have already been registered. Please run hogan_register_field_group() on action hogan/include_field_groups.', 'hogan-core' ), '1.0.0' );
@@ -70,7 +72,7 @@ function hogan_register_field_group( $name, $label, $modules = [], $location = [
 		'fields_after_flexible_content' => $fields_after_flexible_content,
 	];
 
-	add_filter( 'hogan/field_groups', function( $groups ) use ( $group ) {
+	add_filter( 'hogan/field_groups', function( array $groups ) use ( $group ) : array {
 		$groups[] = $group;
 		return $groups;
 	} );
@@ -79,10 +81,11 @@ function hogan_register_field_group( $name, $label, $modules = [], $location = [
 /**
  * Helper function for adding default heading field
  *
- * @param array  $fields ACF fields array.
- * @param object $module Hogan module object.
+ * @param array                $fields ACF fields array.
+ * @param \Dekode\Hogan\Module $module Hogan module object.
+ * @return void
  */
-function hogan_append_heading_field( &$fields, $module ) {
+function hogan_append_heading_field( array &$fields, \Dekode\Hogan\Module $module ) {
 
 	if ( true === apply_filters( 'hogan/module/' . $module->name . '/heading/enabled', true ) ) {
 
@@ -99,10 +102,11 @@ function hogan_append_heading_field( &$fields, $module ) {
 /**
  * Helper function for adding caption field
  *
- * @param array  $fields ACF fields array.
- * @param object $module Hogan module object.
+ * @param array                $fields ACF fields array.
+ * @param \Dekode\Hogan\Module $module Hogan module object.
+ * @return void
  */
-function hogan_append_caption_field( &$fields, $module ) {
+function hogan_append_caption_field( array &$fields, \Dekode\Hogan\Module $module ) {
 
 	if ( true === apply_filters( 'hogan/module/' . $module->name . '/caption/enabled', true ) ) {
 
@@ -125,8 +129,10 @@ function hogan_append_caption_field( &$fields, $module ) {
 
 /**
  * Allowed wp_kses HTML for caption field
+ *
+ * @return array
  */
-function hogan_caption_allowed_html() {
+function hogan_caption_allowed_html() : array {
 
 	return [
 		'strong' => true,


### PR DESCRIPTION
1. Add GitHub Plugin URI
2. Bump required PHP version to 7.0
3. Include counter in base module class, **require updated `load_args_from_layout_content()` in all modules.**
4. Introduce heading field as base module property. **Should be removed in modules.**
5. Use singleton pattern in core. `\Dekode\Hogan\Core::get_instance();`
6. Add filter for the_content priority `hogan/the_content_priority`
7. Add PHP 7.0 parameter and return type decleration, use strict types

## Notat ang punkt 2:
Endringene som er gjort på `load_args_from_layout_content()` i core gjør at det vises en warning for alle moduler, feks: `Warning: Declaration of Dekode\Hogan\Embed::load_args_from_layout_content($content) should be compatible with Dekode\Hogan\Module::load_args_from_layout_content(array $raw_content, int $counter = 0) in /app/public/wp-content/plugins/hogan-embed/class-embed.php on line 22`

Alle moduler burde få oppdatert funksjonssignatur så fort som mulig til:
```php
public function load_args_from_layout_content( array $raw_content, int $counter = 0 ) {
```

# Notat ang. punkt 4:
Heading-feltet er nå i baseklassen og kan fjernes i alle moduler. Brukes kun hvis modulen benytter `hogan_append_heading_field()`

