### PR TITLE
Add Travis-ci config

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,61 @@
+# Travis CI configuration file for Hogan.
+# @link https://travis-ci.org/
+
+# Ditch sudo and use containers.
+# @link https://docs.travis-ci.com/user/migrating-from-legacy/#Why-migrate-to-container-based-infrastructure%3F
+# @link https://docs.travis-ci.com/user/workers/container-based-infrastructure/#Routing-your-build-to-container-based-infrastructure
+sudo: false
+dist: trusty
+
+# Declare project language.
+# @link https://about.travis-ci.org/docs/user/languages/php/
+language: php
+
+# Declare versions of PHP to use. Use one decimal max.
+# @link https://docs.travis-ci.com/user/build-configuration/
+matrix:
+    fast_finish: true
+
+    include:
+        # aliased to a recent 7.0.x version
+        - php: '7.0'
+          env:
+              - SNIFF="1"
+        # aliased to a recent 7.2.x version
+        - php: '7.2'
+          env:
+              - SNIFF="1"
+
+# Use this to prepare your build for testing.
+# Failures in this section will result in build status 'errored'.
+before_script:
+    - export PHPCS_DIR=/tmp/phpcs
+    - export SNIFFS_WPCS_DIR=/tmp/sniffs_wpcs
+    - export SNIFFS_PHPCOMPATIBILITY_DIR=/tmp/sniffs_phpcompataibility
+    # Install CodeSniffer for WordPress Coding Standards checks.
+    - if [[ "$SNIFF" == "1" ]]; then git clone -b master --depth 1 https://github.com/squizlabs/PHP_CodeSniffer.git $PHPCS_DIR; fi
+    # Install WordPress Coding Standards.
+    - if [[ "$SNIFF" == "1" ]]; then git clone -b master --depth 1 https://github.com/WordPress-Coding-Standards/WordPress-Coding-Standards.git $SNIFFS_WPCS_DIR; fi
+    # Install PHP Compatibility.
+    - if [[ "$SNIFF" == "1" ]]; then git clone -b master --depth 1 https://github.com/wimg/PHPCompatibility.git $SNIFFS_PHPCOMPATIBILITY_DIR; fi
+    # Set install path for PHPCS sniffs.
+    - if [[ "$SNIFF" == "1" ]]; then $PHPCS_DIR/bin/phpcs --config-set installed_paths $SNIFFS_WPCS_DIR,$SNIFFS_PHPCOMPATIBILITY_DIR; fi
+    # After CodeSniffer install you should refresh your path.
+    - if [[ "$SNIFF" == "1" ]]; then phpenv rehash; fi
+
+# Run test script commands.
+# Default is specific to project language.
+# All commands must exit with code 0 on success. Anything else is considered failure.
+script:
+    # Search for PHP syntax errors.
+    - find -L . -name '*.php' -print0 | xargs -0 -n 1 -P 4 php -l
+    # WordPress Coding Standards.
+    # @link https://github.com/WordPress-Coding-Standards/WordPress-Coding-Standards
+    # @link https://pear.php.net/package/PHP_CodeSniffer/
+    # Uses a custom ruleset based on WordPress.
+    - if [[ "$SNIFF" == "1" ]]; then $PHPCS_DIR/bin/phpcs -p -s -v . --standard=./phpcs.xml --extensions=php --runtime-set testVersion $TRAVIS_PHP_VERSION; fi
+
+# Receive notifications for build results.
+# @link https://docs.travis-ci.com/user/notifications/#Email-notifications
+notifications:
+    email: false

--- a/includes/class-core.php
+++ b/includes/class-core.php
@@ -219,7 +219,7 @@ class Core {
 		}
 
 		$fields_before_flexible_content = apply_filters( 'hogan/field_group/' . $name . '/fields_before_flexible_content', $fields_before_flexible_content );
-		$fields_after_flexible_content = apply_filters( 'hogan/field_group/' . $name . '/fields_after_flexible_content', $fields_after_flexible_content );
+		$fields_after_flexible_content  = apply_filters( 'hogan/field_group/' . $name . '/fields_after_flexible_content', $fields_after_flexible_content );
 
 		// Include custom fields before and after flexible content field.
 		$field_group_fields =
@@ -254,16 +254,16 @@ class Core {
 		$location = [
 			[
 				[
-					'param' => 'post_type',
+					'param'    => 'post_type',
 					'operator' => '==',
-					'value' => 'post',
+					'value'    => 'post',
 				],
 			],
 			[
 				[
-					'param' => 'post_type',
+					'param'    => 'post_type',
 					'operator' => '==',
-					'value' => 'page',
+					'value'    => 'page',
 				],
 			],
 		];
@@ -316,10 +316,11 @@ class Core {
 	 */
 	private function get_modules_content( \WP_Post $post ) : string {
 
-		$cache_key = 'hogan_modules_' . $post->ID;
+		$cache_key   = 'hogan_modules_' . $post->ID;
 		$cache_group = 'hogan_modules';
 
-		$flexible_content = ''; // wp_cache_get( $cache_key, $cache_group );.
+		$flexible_content = '';
+		// $flexible_content = wp_cache_get( $cache_key, $cache_group ); @codingStandardsIgnoreLine
 
 		if ( empty( $flexible_content ) ) {
 
@@ -352,7 +353,7 @@ class Core {
 				}
 			}
 
-			// wp_cache_add( $cache_key, $flexible_content, $cache_group, 500 );.
+			// wp_cache_add( $cache_key, $flexible_content, $cache_group, 500 ); @codingStandardsIgnoreLine
 		}
 
 		return (string) $flexible_content;

--- a/includes/class-module.php
+++ b/includes/class-module.php
@@ -85,7 +85,7 @@ abstract class Module {
 	 */
 	public function __construct() {
 
-		$this->name = strtolower( substr( strrchr( get_class( $this ), '\\' ), 1 ) );
+		$this->name      = strtolower( substr( strrchr( get_class( $this ), '\\' ), 1 ) );
 		$this->field_key = 'hogan_module_' . $this->name;
 	}
 
@@ -146,7 +146,7 @@ abstract class Module {
 		}
 
 		$this->raw_content = $raw_content;
-		$this->counter = $counter;
+		$this->counter     = $counter;
 	}
 
 	/**

--- a/includes/helper-functions.php
+++ b/includes/helper-functions.php
@@ -63,13 +63,13 @@ function hogan_register_field_group( string $name, string $label, array $modules
 	}
 
 	$group = [
-		'name' => sanitize_key( $name ),
-		'label' => $label,
-		'modules' => $modules,
-		'location' => $location,
-		'hide_on_screen' => $hide_on_screen,
+		'name'                           => sanitize_key( $name ),
+		'label'                          => $label,
+		'modules'                        => $modules,
+		'location'                       => $location,
+		'hide_on_screen'                 => $hide_on_screen,
 		'fields_before_flexible_content' => $fields_before_flexible_content,
-		'fields_after_flexible_content' => $fields_after_flexible_content,
+		'fields_after_flexible_content'  => $fields_after_flexible_content,
 	];
 
 	add_filter( 'hogan/field_groups', function( array $groups ) use ( $group ) : array {
@@ -139,9 +139,9 @@ function hogan_caption_allowed_html() : array {
 
 	return [
 		'strong' => true,
-		'em' => true,
-		'a' => [
-			'href' => true,
+		'em'     => true,
+		'a'      => [
+			'href'   => true,
 			'target' => true,
 		],
 	];

--- a/phpcs.xml
+++ b/phpcs.xml
@@ -7,4 +7,5 @@
 	<rule ref="WordPress-Docs" />
 	<rule ref="WordPress-Extra" />
 	<rule ref="WordPress-VIP" />
+	<rule ref="PHPCompatibility" />
 </ruleset>


### PR DESCRIPTION
Lets start using travis-ci. 💥 

This PR contains:
- Add `PHPCompatibility` to phpcs ruleset (https://github.com/wimg/PHPCompatibility)
- Add `.travis.yml` that will run tests on php 7.0 and php 7.2
- Fix all phpcs warnings