### PR TITLE
Add components loader

### DIFF
--- a/hogan-core.php
+++ b/hogan-core.php
@@ -23,6 +23,8 @@ if ( ! defined( 'ABSPATH' ) ) {
 	exit; // Exit if accessed directly.
 }
 
+define( 'HOGAN_CORE_PATH', plugin_dir_path( __FILE__ ) );
+
 require_once 'includes/class-module.php';
 require_once 'includes/class-core.php';
 require_once 'includes/helper-functions.php';

--- a/hogan-core.php
+++ b/hogan-core.php
@@ -24,12 +24,11 @@ if ( ! defined( 'ABSPATH' ) ) {
 }
 
 define( 'HOGAN_CORE_PATH', plugin_dir_path( __FILE__ ) );
+define( 'HOGAN_CORE_DIR', dirname( plugin_basename( __FILE__ ) ) );
+define( 'HOGAN_CORE_URL', plugin_dir_url( __FILE__ ) );
 
 require_once 'includes/class-module.php';
 require_once 'includes/class-core.php';
 require_once 'includes/helper-functions.php';
 
-$_dir = dirname( plugin_basename( __FILE__ ) );
-$_url = plugin_dir_url( __FILE__ );
-
-\Dekode\Hogan\Core::get_instance( $_dir, $_url );
+\Dekode\Hogan\Core::get_instance( HOGAN_CORE_DIR, HOGAN_CORE_URL );

--- a/includes/helper-functions.php
+++ b/includes/helper-functions.php
@@ -171,3 +171,32 @@ function hogan_args_as_string() : string {
 
 	return implode( ' ', array_filter( $classes ) );
 }
+
+/**
+ * Component
+ *
+ * @param string $name Name of component.
+ * @param array  $args Arguments to pass to the component.
+ */
+function hogan_component( string $name, array $args = [] ) {
+	$components = [
+		'components/' . $name . '/' . $name . '.php',
+		'components/' . $name . '.php',
+	];
+
+	$template = '';
+	foreach ( $components as $component ) {
+		if ( ! $component ) {
+			continue;
+		}
+
+		if ( file_exists( HOGAN_CORE_PATH . '/' . $component ) ) {
+			$template = HOGAN_CORE_PATH . '/' . $component;
+			break;
+		}
+	}
+
+	if ( $template && 0 === validate_file( $template ) ) {
+		include $template;
+	}
+}

--- a/includes/helper-functions.php
+++ b/includes/helper-functions.php
@@ -179,24 +179,24 @@ function hogan_args_as_string() : string {
  * @param array  $args Arguments to pass to the component.
  */
 function hogan_component( string $name, array $args = [] ) {
-	$components = [
+	$templates = [
 		'components/' . $name . '/' . $name . '.php',
 		'components/' . $name . '.php',
 	];
 
-	$template = '';
-	foreach ( $components as $component ) {
-		if ( ! $component ) {
+	$component = '';
+	foreach ( $templates as $template ) {
+		if ( ! $template ) {
 			continue;
 		}
 
-		if ( file_exists( HOGAN_CORE_PATH . '/' . $component ) ) {
-			$template = HOGAN_CORE_PATH . '/' . $component;
+		if ( file_exists( HOGAN_CORE_PATH . '/' . $template ) ) {
+			$component = HOGAN_CORE_PATH . '/' . $template;
 			break;
 		}
 	}
 
-	if ( $template && 0 === validate_file( $template ) ) {
-		include $template;
+	if ( $component && 0 === validate_file( $component ) ) {
+		include $component;
 	}
 }

--- a/includes/helper-functions.php
+++ b/includes/helper-functions.php
@@ -186,10 +186,6 @@ function hogan_component( string $name, array $args = [] ) {
 
 	$component = '';
 	foreach ( $templates as $template ) {
-		if ( ! $template ) {
-			continue;
-		}
-
 		if ( file_exists( HOGAN_CORE_PATH . '/' . $template ) ) {
 			$component = HOGAN_CORE_PATH . '/' . $template;
 			break;


### PR DESCRIPTION
Helper function to load shared frontend componentens accross hogan plugins from core (components will be located at `hogan-core/components/{$component}`). 

Example of how to use a component in a template:
```php
hogan_component( 'button', [
    'url'   => 'https://example.com',
    'title' => 'Example',
    ...
] );
```