### PR TITLE
Check if $post is a WP_Post before checking if post has flexible content

### DIFF
--- a/includes/class-core.php
+++ b/includes/class-core.php
@@ -333,7 +333,7 @@ class Core {
 
 		global $more, $post;
 
-		if ( $this->is_current_post_flexible( $post, $more ) ) {
+		if ( $post instanceof \WP_Post && $this->is_current_post_flexible( $post, $more ) ) {
 			$layouts = $this->get_current_post_layouts( $post );
 
 			foreach ( $layouts as $layout ) {

--- a/includes/class-core.php
+++ b/includes/class-core.php
@@ -301,7 +301,7 @@ class Core {
 	 * @param bool     $more More.
 	 * @return bool
 	 */
-	private function is_current_post_flexible( \WP_Post $post, $more ) {
+	private function is_current_post_flexible( $post, $more ) {
 		return $post instanceof \WP_Post && function_exists( 'get_field' ) && ( $more || is_search() ) && ! post_password_required( $post );
 	}
 
@@ -333,7 +333,7 @@ class Core {
 
 		global $more, $post;
 
-		if ( $post instanceof \WP_Post && $this->is_current_post_flexible( $post, $more ) ) {
+		if ( $this->is_current_post_flexible( $post, $more ) ) {
 			$layouts = $this->get_current_post_layouts( $post );
 
 			foreach ( $layouts as $layout ) {


### PR DESCRIPTION
`is_current_post_flexible` requires the first argument to be a instance of WP_Post. On an empty archive page the global `$post` variable will be `null` and `is_current_post_flexible` will throw an error.