### PR TITLE
Add default inner classname and cleanup template wrapper

### DIFF
--- a/includes/class-module.php
+++ b/includes/class-module.php
@@ -172,27 +172,27 @@ abstract class Module {
 		$this->inner_wrapper_tag = apply_filters( 'hogan/module/inner_wrapper_tag', $this->inner_wrapper_tag, $this );
 		$this->inner_wrapper_tag = apply_filters( 'hogan/module/' . $this->name . '/inner_wrapper_tag', $this->inner_wrapper_tag, $this );
 
-		// Outer wrapper classes with filters for overriding both globally, per module and per module instance.
-		$outer_wrapper_classes = array_merge(
-			apply_filters( 'hogan/module/outer_wrapper_classes', [ 'hogan-module', 'hogan-module-' . $this->name, 'hogan-module-' . $counter ], $this ),
-			apply_filters( 'hogan/module/' . $this->name . '/outer_wrapper_classes', [], $this )
-		);
-		$outer_wrapper_classes = trim( implode( ' ', array_filter( $outer_wrapper_classes ) ) );
-
-		// Inner wrapper classes with filters for overriding both globally, per module and per module instance.
-		$inner_wrapper_classes = array_merge(
-			apply_filters( 'hogan/module/inner_wrapper_classes', [ 'hogan-module-inner' ], $this ),
-			apply_filters( 'hogan/module/' . $this->name . '/inner_wrapper_classes', [], $this )
-		);
-		$inner_wrapper_classes = trim( implode( ' ', array_filter( $inner_wrapper_classes ) ) );
-
 		// Echo opening outer wrapper.
 		if ( ! empty( $this->outer_wrapper_tag ) ) {
+			// Outer wrapper classes with filters for overriding both globally, per module and per module instance.
+			$outer_wrapper_classes = array_merge(
+				apply_filters( 'hogan/module/outer_wrapper_classes', [ 'hogan-module', 'hogan-module-' . $this->name, 'hogan-module-' . $counter ], $this ),
+				apply_filters( 'hogan/module/' . $this->name . '/outer_wrapper_classes', [], $this )
+			);
+			$outer_wrapper_classes = trim( implode( ' ', array_filter( $outer_wrapper_classes ) ) );
+
 			echo sprintf( '<%s id="%s" class="%s">', esc_attr( $this->outer_wrapper_tag ), esc_attr( 'module-' . $counter ), esc_attr( $outer_wrapper_classes ) );
 		}
 
 		// Echo inner wrapper.
 		if ( ! empty( $this->inner_wrapper_tag ) ) {
+			// Inner wrapper classes with filters for overriding both globally, per module and per module instance.
+			$inner_wrapper_classes = array_merge(
+				apply_filters( 'hogan/module/inner_wrapper_classes', [ 'hogan-module-inner' ], $this ),
+				apply_filters( 'hogan/module/' . $this->name . '/inner_wrapper_classes', [], $this )
+			);
+			$inner_wrapper_classes = trim( implode( ' ', array_filter( $inner_wrapper_classes ) ) );
+
 			echo sprintf( '<%s class="%s">', esc_attr( $this->inner_wrapper_tag ), esc_attr( $inner_wrapper_classes ) );
 		}
 	}

--- a/includes/class-module.php
+++ b/includes/class-module.php
@@ -175,11 +175,10 @@ abstract class Module {
 		// Echo opening outer wrapper.
 		if ( ! empty( $this->outer_wrapper_tag ) ) {
 			// Outer wrapper classes with filters for overriding both globally, per module and per module instance.
-			$outer_wrapper_classes = array_merge(
+			$outer_wrapper_classes = hogan_classnames(
 				apply_filters( 'hogan/module/outer_wrapper_classes', [ 'hogan-module', 'hogan-module-' . $this->name, 'hogan-module-' . $counter ], $this ),
 				apply_filters( 'hogan/module/' . $this->name . '/outer_wrapper_classes', [], $this )
 			);
-			$outer_wrapper_classes = trim( implode( ' ', array_filter( $outer_wrapper_classes ) ) );
 
 			echo sprintf( '<%s id="%s" class="%s">', esc_attr( $this->outer_wrapper_tag ), esc_attr( 'module-' . $counter ), esc_attr( $outer_wrapper_classes ) );
 		}
@@ -187,11 +186,10 @@ abstract class Module {
 		// Echo inner wrapper.
 		if ( ! empty( $this->inner_wrapper_tag ) ) {
 			// Inner wrapper classes with filters for overriding both globally, per module and per module instance.
-			$inner_wrapper_classes = array_merge(
+			$inner_wrapper_classes = hogan_classnames(
 				apply_filters( 'hogan/module/inner_wrapper_classes', [ 'hogan-module-inner' ], $this ),
 				apply_filters( 'hogan/module/' . $this->name . '/inner_wrapper_classes', [], $this )
 			);
-			$inner_wrapper_classes = trim( implode( ' ', array_filter( $inner_wrapper_classes ) ) );
 
 			echo sprintf( '<%s class="%s">', esc_attr( $this->inner_wrapper_tag ), esc_attr( $inner_wrapper_classes ) );
 		}

--- a/includes/class-module.php
+++ b/includes/class-module.php
@@ -180,7 +180,11 @@ abstract class Module {
 				apply_filters( 'hogan/module/' . $this->name . '/outer_wrapper_classes', [], $this )
 			);
 
-			echo sprintf( '<%s id="%s" class="%s">', esc_attr( $this->outer_wrapper_tag ), esc_attr( 'module-' . $counter ), esc_attr( $outer_wrapper_classes ) );
+			printf( '<%s id="%s" class="%s">',
+				esc_attr( $this->outer_wrapper_tag ),
+				esc_attr( 'module-' . $counter ),
+				esc_attr( $outer_wrapper_classes )
+			);
 		}
 
 		// Echo inner wrapper.
@@ -191,7 +195,10 @@ abstract class Module {
 				apply_filters( 'hogan/module/' . $this->name . '/inner_wrapper_classes', [], $this )
 			);
 
-			echo sprintf( '<%s class="%s">', esc_attr( $this->inner_wrapper_tag ), esc_attr( $inner_wrapper_classes ) );
+			printf( '<%s class="%s">',
+				esc_attr( $this->inner_wrapper_tag ),
+				esc_attr( $inner_wrapper_classes )
+			);
 		}
 	}
 
@@ -204,12 +211,12 @@ abstract class Module {
 
 		// Echo closing inner wrapper.
 		if ( ! empty( $this->inner_wrapper_tag ) ) {
-			echo sprintf( '</%s>', esc_attr( $this->inner_wrapper_tag ) );
+			printf( '</%s>', esc_attr( $this->inner_wrapper_tag ) );
 		}
 
 		// Echo closing outer wrapper.
 		if ( ! empty( $this->outer_wrapper_tag ) ) {
-			echo sprintf( '</%s>', esc_attr( $this->outer_wrapper_tag ) );
+			printf( '</%s>', esc_attr( $this->outer_wrapper_tag ) );
 		}
 	}
 

--- a/includes/class-module.php
+++ b/includes/class-module.php
@@ -181,7 +181,7 @@ abstract class Module {
 
 		// Inner wrapper classes with filters for overriding both globally, per module and per module instance.
 		$inner_wrapper_classes = array_merge(
-			apply_filters( 'hogan/module/inner_wrapper_classes', [], $this ),
+			apply_filters( 'hogan/module/inner_wrapper_classes', [ 'hogan-module-inner' ], $this ),
 			apply_filters( 'hogan/module/' . $this->name . '/inner_wrapper_classes', [], $this )
 		);
 		$inner_wrapper_classes = trim( implode( ' ', array_filter( $inner_wrapper_classes ) ) );


### PR DESCRIPTION
- Add default class to inner wrapper (`.hogan-module-inner`)
- Use `hogan_classnames` to join classnames
- Move classname filter so they don't run when tag is empty
- Use `printf` istead of `echo sprintf`.