### PR TITLE
Only run `enqueue_assets` once per module per page

### DIFF
--- a/includes/class-core.php
+++ b/includes/class-core.php
@@ -334,7 +334,8 @@ class Core {
 		global $more, $post;
 
 		if ( $this->is_current_post_flexible( $post, $more ) ) {
-			$layouts = $this->get_current_post_layouts( $post );
+			$layouts          = $this->get_current_post_layouts( $post );
+			$enqueued_modules = [];
 
 			foreach ( $layouts as $layout ) {
 
@@ -345,7 +346,8 @@ class Core {
 				// Get the right module.
 				$module = true === isset( $this->_modules[ $layout['acf_fc_layout'] ] ) ? $this->_modules[ $layout['acf_fc_layout'] ] : null;
 
-				if ( $module instanceof Module && method_exists( $module, 'enqueue_assets' ) ) {
+				if ( $module instanceof Module && ! in_array( $module->name, $enqueued_modules, true ) && method_exists( $module, 'enqueue_assets' ) ) {
+					$enqueued_modules[] = $module->name;
 					$module->enqueue_assets();
 				}
 			}


### PR DESCRIPTION
Make sure `enqueue_assets` only run once per module per page.

We need it to run only once. If you for example use `wp_localize_script` to add script params it will run on every module and we will end up having duplicate content in the dom.