### PR TITLE
Remove default post types and add filter to easly add post types

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,6 +52,24 @@ See the [Wiki](https://github.com/DekodeInteraktiv/hogan-core/wiki/Guidelines-fo
 ## Usage
 By default you will get a ACF Flexible Content group with all activated modules for post types `post` and `page`. The built in wysiwyg editor will be removed.
 
+### Adding Hogan to post types.
+Hogan is by default not added to any post types. Use the filter
+`hogan/supported_post_types` to declare support to different post types.
+
+```php
+function supported_post_types( $post_types, $field_group_name ) {
+	$post_types[] = 'post';
+	$post_types[] = 'page';
+
+	return $post_types;
+}
+add_filter( 'hogan/supported_post_types', 'supported_post_types', 10, 2 );
+```
+
+By default `hogan/supported_post_types` adds all field groups. The second
+argument is the field group name if you only need specific field groups on some
+post types.
+
 ### Customizing the default field group
 The default field group can be customized using these filters:
 - `hogan/field_group/default/fields_before_flexible_content` Insert custom fields before modules.
@@ -146,6 +164,10 @@ We’re going to assume that you have installed `git`, `svn`, `php`, `apache` an
 For more info see https://make.wordpress.org/cli/handbook/plugin-unit-tests/#running-tests-locally
 
 ## Changelog
+
+### 1.1.0
+#### Breaking changes
+- Hogan is no longer added by default to the post types `post` and `page`. Use the filter `hogan/supported_post_types` to declare Hogan support to different post types.
 
 ### 1.0.17
 - Added custom blockquote btn to hogan toolbar. Only appears if TinyMCEPlugin [Blockquote with cite](https://github.com/DekodeInteraktiv/WP-Snippets) is added to MU-plugins in the project you are working on.

--- a/README.md
+++ b/README.md
@@ -166,7 +166,7 @@ For more info see https://make.wordpress.org/cli/handbook/plugin-unit-tests/#run
 
 ### 1.1.0
 #### Breaking changes
-- Hogan is no longer added by default to the post types `post` and `page`. Use the filter `hogan/supported_post_types` to declare Hogan support to different post types.
+- Hogan is no longer added by default to the post types `post`. Use the filter `hogan/supported_post_types` to declare Hogan support to different post types.
 
 ### 1.0.17
 - Added custom blockquote btn to hogan toolbar. Only appears if TinyMCEPlugin [Blockquote with cite](https://github.com/DekodeInteraktiv/WP-Snippets) is added to MU-plugins in the project you are working on.

--- a/README.md
+++ b/README.md
@@ -53,13 +53,12 @@ See the [Wiki](https://github.com/DekodeInteraktiv/hogan-core/wiki/Guidelines-fo
 By default you will get a ACF Flexible Content group with all activated modules for post types `post` and `page`. The built in wysiwyg editor will be removed.
 
 ### Adding Hogan to post types.
-Hogan is by default not added to any post types. Use the filter
-`hogan/supported_post_types` to declare support to different post types.
+Hogan is by default added to pages. Use the filter `hogan/supported_post_types`
+to declare support to other post types.
 
 ```php
 function supported_post_types( $post_types, $field_group_name ) {
 	$post_types[] = 'post';
-	$post_types[] = 'page';
 
 	return $post_types;
 }

--- a/includes/class-core.php
+++ b/includes/class-core.php
@@ -243,6 +243,8 @@ class Core {
 				],
 			], $fields_after_flexible_content );
 
+		$location = array_merge( $this->get_post_type_location( $name ), $location );
+
 		acf_add_local_field_group(
 			[
 				'key'            => 'hogan_' . $name, // i.e. hogan_default.
@@ -255,28 +257,38 @@ class Core {
 	}
 
 	/**
+	 * Add location rule to post types.
+	 *
+	 * @param string $name Field group name.
+	 *
+	 * @return array New location rules.
+	 */
+	private function get_post_type_location( string $name ) : array {
+		$supports_hogan_field_group = apply_filters( 'hogan/supported_post_types', [], $name );
+
+		$location = [];
+
+		if ( ! empty( $supports_hogan_field_group ) && is_array( $supports_hogan_field_group ) ) {
+			foreach ( $supports_hogan_field_group as $post_type ) {
+				$location[] = [
+					[
+						'param'    => 'post_type',
+						'operator' => '==',
+						'value'    => $post_type,
+					],
+				];
+			}
+		}
+
+		return $location;
+	}
+
+	/**
 	 * Register default field group for modules.
 	 *
 	 * @return void
 	 */
 	public function register_default_field_group() {
-
-		$location = [
-			[
-				[
-					'param'    => 'post_type',
-					'operator' => '==',
-					'value'    => 'post',
-				],
-			],
-			[
-				[
-					'param'    => 'post_type',
-					'operator' => '==',
-					'value'    => 'page',
-				],
-			],
-		];
 
 		$hide_on_screen = [
 			'the_content',
@@ -291,7 +303,7 @@ class Core {
 			'send-trackbacks',
 		];
 
-		hogan_register_field_group( 'default', __( 'Content Modules', 'hogan-core' ), [], $location, $hide_on_screen );
+		hogan_register_field_group( 'default', __( 'Content Modules', 'hogan-core' ), [], [], $hide_on_screen );
 	}
 
 	/**

--- a/includes/class-core.php
+++ b/includes/class-core.php
@@ -264,7 +264,7 @@ class Core {
 	 * @return array New location rules.
 	 */
 	private function get_post_type_location( string $name ) : array {
-		$supports_hogan_field_group = apply_filters( 'hogan/supported_post_types', [], $name );
+		$supports_hogan_field_group = apply_filters( 'hogan/supported_post_types', [ 'page' ], $name );
 
 		$location = [];
 


### PR DESCRIPTION
Fjerner `post` så den ikke er med i utgangspunktet.

For å legge til post typer kan man bruke et filter som man returerer post type navnet. Hogan tar hånd om resten.

```php
function supported_post_types( $post_types, $field_group_name ) {
	$post_types[] = 'post';

	return $post_types;
}
add_filter( 'hogan/supported_post_types', 'supported_post_types', 10, 2 );
```

Usikker på filternavnet. Kom gjerne med bedre forslag.