### PR TITLE
Check php version and bail out early if required version isn’t met

### DIFF
--- a/README.md
+++ b/README.md
@@ -172,6 +172,9 @@ For more info see https://make.wordpress.org/cli/handbook/plugin-unit-tests/#run
 
 ## Changelog
 
+### Unreleased
+- Check if server runs required php version
+
 ### 1.1.0
 #### Breaking changes
 - Hogan is no longer added by default to the post types `post`. Use the filter `hogan/supported_post_types` to declare Hogan support to different post types.

--- a/hogan-core.php
+++ b/hogan-core.php
@@ -17,8 +17,6 @@
  * @author Dekode
  */
 
-declare( strict_types = 1 );
-
 if ( ! defined( 'ABSPATH' ) ) {
 	exit; // Exit if accessed directly.
 }
@@ -27,6 +25,40 @@ define( 'HOGAN_CORE_VERSION', '1.0.17' );
 define( 'HOGAN_CORE_PATH', plugin_dir_path( __FILE__ ) );
 define( 'HOGAN_CORE_DIR', dirname( plugin_basename( __FILE__ ) ) );
 define( 'HOGAN_CORE_URL', plugin_dir_url( __FILE__ ) );
+define( 'HOGAN_CORE_PHP_REQUIRED_VERSION', '7' );
+
+/*
+ * Check the PHP version, if it's not a supported version, return without running
+ * any more code as the user will not be able to use Hogan.
+ */
+if ( version_compare( phpversion(), HOGAN_CORE_PHP_REQUIRED_VERSION, '<' ) ) {
+	add_action( 'admin_notices', function() {
+		$screen = get_current_screen();
+
+		// Only display message on the plugin screen.
+		if ( 'plugins' !== $screen->id ) {
+			return;
+		}
+		?>
+		<div class="notice notice-error">
+			<?php
+			printf( '<p><strong>%s</strong> &#151; %s</p>',
+				esc_html__( 'Hogan Disabled', 'hogan-core' ),
+				esc_html__( 'You are running an unsupported version of PHP.', 'hogan-core' )
+			);
+
+			/* translators: %s: required PHP version */
+			printf( '<p>' . esc_html__( 'Hogan requires PHP Version %s, please upgrade to use Hogan.', 'hogan-core' ) . '</p>',
+				esc_html( HOGAN_CORE_PHP_REQUIRED_VERSION )
+			);
+			?>
+		</div>
+		<?php
+	} );
+
+	// Bail out now so no additional code is run.
+	return;
+}
 
 require_once 'includes/class-module.php';
 require_once 'includes/class-core.php';


### PR DESCRIPTION
Hogan will produce fetal errors if you try to activate the plugin on a site that runs php 5.x. Lets bail out early and warn the user about the required version.

![image](https://user-images.githubusercontent.com/1415747/36302749-e69e5024-1309-11e8-843d-be13f6aebca3.png)
