### PR TITLE
Add cached version of url_to_postid

### DIFF
--- a/README.md
+++ b/README.md
@@ -172,6 +172,9 @@ For more info see https://make.wordpress.org/cli/handbook/plugin-unit-tests/#run
 
 ## Changelog
 
+### Unreleased
+- Added `hogan_url_to_postid` helper function. A cached version of `url_to_postid`.
+
 ### 1.1.1
 - Check if server runs required php version
 - Added filters to hogan toolbars. `hogan/tinymce/toolbar/{hogan|hogan_caption}`

--- a/includes/helper-functions.php
+++ b/includes/helper-functions.php
@@ -322,3 +322,28 @@ function hogan_component( string $name, array $args = [] ) {
 		include $component;
 	}
 }
+
+/**
+ * Cached version of url_to_postid, which can be expensive.
+ *
+ * Examine a url and try to determine the post ID it represents.
+ *
+ * @param string $url Permalink to check.
+ * @return int Post ID, or 0 on failure.
+ */
+function hogan_url_to_postid( string $url ) : int {
+	// Sanity check; no URLs not from this site.
+	if ( wp_parse_url( $url, PHP_URL_HOST ) !== wp_parse_url( home_url(), PHP_URL_HOST ) ) {
+		return 0;
+	}
+
+	$cache_key = md5( $url );
+	$post_id   = wp_cache_get( $cache_key, 'url_to_postid' );
+
+	if ( false === $post_id ) {
+		$post_id = url_to_postid( $url ); // phpcs:ignore
+		wp_cache_set( $cache_key, $post_id, 'url_to_postid', 3 * HOUR_IN_SECONDS );
+	}
+
+	return (int) $post_id;
+}


### PR DESCRIPTION
We are using `url_to_postid`, which can be expensive . Lets a cached version.