### PR TITLE
Update PHPCS config

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -45,7 +45,7 @@ script:
     fi
   - |
     if [[ "$WP_TRAVISCI" == "phpcs" ]] ; then
-      phpcs -p -s -v . --standard=./phpcs.xml --extensions=php --runtime-set testVersion $TRAVIS_PHP_VERSION
+      phpcs --runtime-set testVersion $TRAVIS_PHP_VERSION
     fi
 
 notifications:

--- a/phpcs.xml
+++ b/phpcs.xml
@@ -1,6 +1,14 @@
 <?xml version="1.0"?>
 <ruleset name="Hogan Coding Standards">
 	<description>Write code using Hogan's standards and Hogan will stay happy!</description>
+
+	<arg value="ps" />
+	<arg name="extensions" value="php" />
+	<config name="text_domain" value="hogan-core" />
+
+	<file>.</file>
+	<exclude-pattern>./vendor</exclude-pattern>
+
 	<rule ref="WordPress-Core">
 		<exclude name="WordPress.NamingConventions.ValidHookName.UseUnderscores" />
 	</rule>
@@ -8,10 +16,10 @@
 	<rule ref="WordPress-Extra" />
 	<rule ref="WordPress-VIP" />
 	<rule ref="PHPCompatibility" />
-
 	<rule ref="WordPress.XSS.EscapeOutput">
 		<properties>
 			<property name="customAutoEscapedFunctions" value="hogan_attributes" type="array" />
 		</properties>
 	</rule>
+	<rule ref="Generic.Arrays.DisallowLongArraySyntax.Found" />
 </ruleset>


### PR DESCRIPTION
- Moved arguments to config file. You can now just use the command `phpcs` instead of `phpcs -p -s -v . --standard=./phpcs.xml --extensions=php`.
- Added `text_domain` to config to throw an error if wrong text domain is used.
- Added rule to throw an error if long arrow syntax is used.